### PR TITLE
Item size calculation fix - Round up

### DIFF
--- a/src/sly.js
+++ b/src/sly.js
@@ -210,7 +210,7 @@
 					// Item
 					var $item = $(element);
 					var rect = element.getBoundingClientRect();
-					var itemSize = round(o.horizontal ? rect.width || rect.right - rect.left : rect.height || rect.bottom - rect.top);
+					var itemSize = Math.ceil(o.horizontal ? rect.width || rect.right - rect.left : rect.height || rect.bottom - rect.top);
 					var itemMarginStart = getPx($item, o.horizontal ? 'marginLeft' : 'marginTop');
 					var itemMarginEnd = getPx($item, o.horizontal ? 'marginRight' : 'marginBottom');
 					var itemSizeFull = itemSize + itemMarginStart + itemMarginEnd;


### PR DESCRIPTION
This fixes the item calculation issue that hides last element of the scrollable items in certain conditions. Rounding up to the next int fixes this bug and has little to none implications in the visual aspect.
